### PR TITLE
🐛 Typing - Fix  Registrable Type to be compatible with py 39

### DIFF
--- a/magicparse/__init__.py
+++ b/magicparse/__init__.py
@@ -26,7 +26,7 @@ def parse(
     return schema_definition.parse(data)
 
 
-Registrable = Schema | Transform
+Registrable = Union[Schema, Transform]
 
 
 def register(items: Union[Registrable, List[Registrable]]) -> None:


### PR DESCRIPTION
la notation `<TYPE1> | <TYPE2>` n'apparait qu'en python 3.10.