### PR TITLE
:sparkles: StreamParsing - Add streaming parsing capacity

### DIFF
--- a/magicparse/__init__.py
+++ b/magicparse/__init__.py
@@ -1,11 +1,12 @@
 from io import BytesIO
+from typing import Any, Dict, List, Tuple, Union
 
+from .callbacks import OnInvalidRowCallback, OnValidRowCallback
 from .schema import Schema, builtins as builtins_schemas
 from .post_processors import PostProcessor, builtins as builtins_post_processors
 from .pre_processors import PreProcessor, builtins as builtins_pre_processors
 from .transform import Transform
 from .type_converters import TypeConverter, builtins as builtins_type_converters
-from typing import Any, Dict, List, Tuple, Union
 from .validators import Validator, builtins as builtins_validators
 
 
@@ -24,6 +25,20 @@ def parse(
 ) -> Tuple[List[dict], List[dict]]:
     schema_definition = Schema.build(schema_options)
     return schema_definition.parse(data)
+
+
+def stream_parse(
+    data: Union[bytes, BytesIO],
+    schema_options: Dict[str, Any],
+    on_valid_parsed_row: OnValidRowCallback,
+    on_invalid_parsed_row: OnInvalidRowCallback,
+) -> None:
+    schema_definition = Schema.build(schema_options)
+    return schema_definition.stream_parse(
+        data=data,
+        on_valid_parsed_row=on_valid_parsed_row,
+        on_invalid_parsed_row=on_invalid_parsed_row,
+    )
 
 
 Registrable = Union[Schema, Transform]

--- a/magicparse/callbacks.py
+++ b/magicparse/callbacks.py
@@ -1,0 +1,11 @@
+from typing import Any, Dict, List, Protocol
+
+
+class OnValidRowCallback(Protocol):
+    def __call__(self, index: int, parsed_row: Dict[str, Any], raw_data: Any) -> None:
+        ...
+
+
+class OnInvalidRowCallback(Protocol):
+    def __call__(self, errors_info: List[Dict[str, Any]], raw_data: Any) -> None:
+        ...


### PR DESCRIPTION
Il nous faut d'une manière ou d'une autre le moyen de récuperer la ligne lu en cours dans magicparse. L'actuelle version ne le permet pas (parse renvoie directement une liste de dict). 
Après réflexion avec @antoine-b-smartway , on a convenu que l'ajout d'un callback qui expose chaque résultat de row/error était la manière la plus flex de permettre la chose)  

Faudra faire très attention à la version Xcell dans les projets micro-service, le reader ne sera sans doute pas valide (mais cela ne fait pas partie de la lib de base)