### PR TITLE
🐛 fix quote parameter

### DIFF
--- a/magicparse/schema.py
+++ b/magicparse/schema.py
@@ -80,16 +80,18 @@ class CsvSchema(Schema):
     def __init__(self, options: Dict[str, Any]) -> None:
         super().__init__(options)
         self.delimiter = options.get("delimiter", ",")
-        self.quotechar = options.get("quotechar", '"')
+        self.quotechar = options.get("quotechar", None)
 
     def get_reader(self, stream: BytesIO) -> Iterable[List[str]]:
         stream_reader = codecs.getreader(self.encoding)
         stream_content = stream_reader(stream)
-
+        csv_quoting = csv.QUOTE_NONE
+        if self.quotechar:
+            csv_quoting = csv.QUOTE_MINIMAL
         return csv.reader(
             stream_content,
             delimiter=self.delimiter,
-            quoting=csv.QUOTE_MINIMAL,
+            quoting=csv_quoting,
             quotechar=self.quotechar,
         )
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -221,6 +221,7 @@ class TestQuotingSetting(TestCase):
         schema = Schema.build(
             {
                 "file_type": "csv",
+                "quotechar": "",
                 "has_header": True,
                 "fields": [{"key": "column_1", "type": "decimal", "column-number": 1}],
             }
@@ -246,6 +247,7 @@ class TestQuotingSetting(TestCase):
         schema = Schema.build(
             {
                 "file_type": "csv",
+                "quotechar": '"',
                 "has_header": True,
                 "fields": [{"key": "column_1", "type": "decimal", "column-number": 1}],
             }
@@ -253,6 +255,17 @@ class TestQuotingSetting(TestCase):
         rows, errors = schema.parse(b'column_1\n"6.66"')
         assert rows == [{"column_1": Decimal("6.66")}]
         assert not errors
+
+    def test_asymetrical_quote(self):
+        schema = Schema.build(
+            {
+                "file_type": "csv",
+                "has_header": True,
+                "fields": [{"key": "column_1", "type": "str", "column-number": 1}],
+            }
+        )
+        rows, errors = schema.parse(b'column_1\n"test ""quoting""')
+        assert rows == [{"column_1": '"test ""quoting""'}]
 
 
 class TestRegister(TestCase):


### PR DESCRIPTION
to assure retro compatibility of magic parser by using QUOTE_NONE in default